### PR TITLE
修正前缀使用方式

### DIFF
--- a/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onGroupMessage.java
+++ b/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onGroupMessage.java
@@ -48,7 +48,7 @@ public class onGroupMessage implements Listener {
             for(String prefix : plugin.getConfig().getStringList("bot.requite-special-word-prefix.prefix")){
                 if(e.getMessage().startsWith(prefix)){
                     allowPrefix = true;
-                    formatText = formatText.replace(prefix,"");
+                    formatText = formatText.substring(1);
                     break;
                 }
             }

--- a/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onGroupMessage.java
+++ b/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onGroupMessage.java
@@ -48,7 +48,7 @@ public class onGroupMessage implements Listener {
             for(String prefix : plugin.getConfig().getStringList("bot.requite-special-word-prefix.prefix")){
                 if(e.getMessage().startsWith(prefix)){
                     allowPrefix = true;
-                    formatText = formatText.substring(1);
+                    formatText = formatText.substring(prefix.length());
                     break;
                 }
             }

--- a/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onPlayerMessage.java
+++ b/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onPlayerMessage.java
@@ -48,7 +48,7 @@ public class onPlayerMessage implements Listener {
                 for(String prefix : plugin.getConfig().getStringList("general.requite-special-word-prefix.prefix")){
                     if(e.getMessage().startsWith(prefix)){
                         allowPrefix = true;
-                        formatText = formatText.substring(1);
+                        formatText = formatText.substring(prefix.length());
                         break;
                     }
                 }

--- a/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onPlayerMessage.java
+++ b/Chat2QQ-Bukkit/src/main/java/me/dreamvoid/chat2qq/bukkit/listener/onPlayerMessage.java
@@ -48,7 +48,7 @@ public class onPlayerMessage implements Listener {
                 for(String prefix : plugin.getConfig().getStringList("general.requite-special-word-prefix.prefix")){
                     if(e.getMessage().startsWith(prefix)){
                         allowPrefix = true;
-                        formatText = formatText.replace(prefix,"");
+                        formatText = formatText.substring(1);
                         break;
                     }
                 }

--- a/Chat2QQ-Bungee/src/main/java/me/dreamvoid/chat2qq/bungee/listener/onGroupMessage.java
+++ b/Chat2QQ-Bungee/src/main/java/me/dreamvoid/chat2qq/bungee/listener/onGroupMessage.java
@@ -45,7 +45,7 @@ public class onGroupMessage implements Listener {
             for(String prefix : plugin.getConfig().getStringList("bot.requite-special-word-prefix.prefix")){
                 if(e.getMessage().startsWith(prefix)){
                     allowPrefix = true;
-                    formatText = formatText.substring(1);
+                    formatText = formatText.substring(prefix.length());
                     break;
                 }
             }

--- a/Chat2QQ-Bungee/src/main/java/me/dreamvoid/chat2qq/bungee/listener/onGroupMessage.java
+++ b/Chat2QQ-Bungee/src/main/java/me/dreamvoid/chat2qq/bungee/listener/onGroupMessage.java
@@ -45,7 +45,7 @@ public class onGroupMessage implements Listener {
             for(String prefix : plugin.getConfig().getStringList("bot.requite-special-word-prefix.prefix")){
                 if(e.getMessage().startsWith(prefix)){
                     allowPrefix = true;
-                    formatText = formatText.replace(prefix,"");
+                    formatText = formatText.substring(1);
                     break;
                 }
             }

--- a/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onGroupMessage.java
+++ b/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onGroupMessage.java
@@ -41,7 +41,7 @@ public class onGroupMessage implements Listener {
             for(String prefix : plugin.getConfig().getStringList("bot.requite-special-word-prefix.prefix")){
                 if(e.getMessage().startsWith(prefix)){
                     allowPrefix = true;
-                    formatText = formatText.replace(prefix,"");
+                    formatText = formatText.substring(1);
                     break;
                 }
             }

--- a/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onGroupMessage.java
+++ b/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onGroupMessage.java
@@ -41,7 +41,7 @@ public class onGroupMessage implements Listener {
             for(String prefix : plugin.getConfig().getStringList("bot.requite-special-word-prefix.prefix")){
                 if(e.getMessage().startsWith(prefix)){
                     allowPrefix = true;
-                    formatText = formatText.substring(1);
+                    formatText = formatText.substring(prefix.length());
                     break;
                 }
             }

--- a/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onPlayerMessage.java
+++ b/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onPlayerMessage.java
@@ -36,7 +36,7 @@ public class onPlayerMessage implements Listener {
                 for(String prefix : plugin.getConfig().getStringList("general.requite-special-word-prefix.prefix")){
                     if(e.getMessage().startsWith(prefix)){
                         allowPrefix = true;
-                        formatText = formatText.replace(prefix,"");
+                        formatText = formatText.substring(1);
                         break;
                     }
                 }

--- a/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onPlayerMessage.java
+++ b/Chat2QQ-Nukkit/src/main/java/me/dreamvoid/chat2qq/nukkit/listener/onPlayerMessage.java
@@ -36,7 +36,7 @@ public class onPlayerMessage implements Listener {
                 for(String prefix : plugin.getConfig().getStringList("general.requite-special-word-prefix.prefix")){
                     if(e.getMessage().startsWith(prefix)){
                         allowPrefix = true;
-                        formatText = formatText.substring(1);
+                        formatText = formatText.substring(prefix.length());
                         break;
                     }
                 }


### PR DESCRIPTION
使用前缀时应当仅替换首字符，而非把消息中的所有前缀字符都替换成空字符。

（其实并不会Java，但是看了下感觉挺简单就直接pr了，希望没改错orz